### PR TITLE
Handle large input files more efficiently

### DIFF
--- a/src/org/knotation/cli.clj
+++ b/src/org/knotation/cli.clj
@@ -15,6 +15,7 @@ Options:
   -t FORMAT, -w FORMAT  --to=FORMAT, --write=FORMAT
   -o FILENAME           --output=FILENAME
   -s                    --sequential-blank-nodes
+  -e                    --fail-on-error
   -v                    --version
   -h                    --help")
 
@@ -37,6 +38,7 @@ Options:
     :default []
     :assoc-fn (fn [m k v] (update-in m [k] conj v))]
    ["-s" "--sequential-blank-nodes" "Outputs sequential blank nodes instead of random ones. Useful for testing purposes."]
+   ["-e" "--fail-on-error" "Fail hard on any parse error"]
    ["-v" "--version"]
    ["-h" "--help"]])
 
@@ -53,6 +55,7 @@ Options:
    run and exit."
   [args]
   (let [{:keys [options arguments errors summary]} (parse-opts args cli-options)]
+    (reset! api/fail-on-error (:fail-on-error options))
     (cond
       (:help options) (println usage)
       (:version options) (println (version))

--- a/src/org/knotation/cli.clj
+++ b/src/org/knotation/cli.clj
@@ -14,8 +14,9 @@ Options:
   -f FORMAT, -r FORMAT  --from=FORMAT, --read=FORMAT
   -t FORMAT, -w FORMAT  --to=FORMAT, --write=FORMAT
   -o FILENAME           --output=FILENAME
+  -e                    --fail-on-error=ERR_NUM
+  -i                    --ignore-errors
   -s                    --sequential-blank-nodes
-  -e                    --fail-on-error
   -v                    --version
   -h                    --help")
 
@@ -37,8 +38,9 @@ Options:
    ["-c" "--context FILENAME" "File for context"
     :default []
     :assoc-fn (fn [m k v] (update-in m [k] conj v))]
+   ["-e" "--fail-on-error ERR_NUM" "Number of errors to fail after"] 
+   ["-i" "--ignore-errors" "Do not fail on any error"]
    ["-s" "--sequential-blank-nodes" "Outputs sequential blank nodes instead of random ones. Useful for testing purposes."]
-   ["-e" "--fail-on-error" "Fail hard on any parse error"]
    ["-v" "--version"]
    ["-h" "--help"]])
 
@@ -55,7 +57,8 @@ Options:
    run and exit."
   [args]
   (let [{:keys [options arguments errors summary]} (parse-opts args cli-options)]
-    (reset! api/fail-on-error (:fail-on-error options))
+    (reset! st/fail-on-error (not (:ignore-errors options)))
+    (reset! st/fail-on-error-number (or (:fail-on-error options) 1))
     (cond
       (:help options) (println usage)
       (:version options) (println (version))

--- a/src/org/knotation/clj_api.clj
+++ b/src/org/knotation/clj_api.clj
@@ -79,7 +79,7 @@
                  input-format 
                  initial-state 
                  (java.io.ByteArrayInputStream. (.getBytes content "UTF-8")))]
-    (if @fail-on-error
+    (when @fail-on-error
       (handle-errors states content))
     states))
 
@@ -93,7 +93,7 @@
                 (or force-format (path-format path))
                 (or initial-state st/default-state)
                 (io/input-stream path))]
-    (if @fail-on-error
+    (when @fail-on-error
       (handle-errors states path))
     states))
 

--- a/src/org/knotation/clj_api.clj
+++ b/src/org/knotation/clj_api.clj
@@ -12,24 +12,6 @@
             [org.knotation.ttl :as ttl]
             [org.knotation.nq :as nq]))
 
-(def fail-on-error (atom false))
-
-(defn handle-errors
-  "Given a lazy sequence of states,
-   determine if there are any error states.
-   If so, print error message and exit with status 1."
-  [states content]
-  (when-let [errors (st/filter-errors states)]
-    (println
-      (format
-        "Failed to read from '%s' due to %d error(s):\n\t%s"
-        (if (< (count content) 50)
-          content
-          (str (subs content 0 50) " ..."))
-        (count errors)
-        (st/join-errors errors)))
-    (System/exit 1)))
-
 ; For Apache Jena's preferred file extnesions see
 ; https://jena.apache.org/documentation/io/#command-line-tools
 
@@ -75,13 +57,10 @@
    and a content string
    return a lazy sequence of state maps."
   [input-format initial-state content]
-  (let [states (read-input 
-                 input-format 
-                 initial-state 
-                 (java.io.ByteArrayInputStream. (.getBytes content "UTF-8")))]
-    (when @fail-on-error
-      (handle-errors states content))
-    states))
+  (read-input 
+     input-format 
+     initial-state 
+     (java.io.ByteArrayInputStream. (.getBytes content "UTF-8"))))
 
 (defn read-path
   "Given a format keyword (or nil to detect the format),
@@ -89,13 +68,10 @@
    and a file path (string),
    return a lazy sequence of states."
   [force-format initial-state path]
-  (let [states (read-input
-                (or force-format (path-format path))
-                (or initial-state st/default-state)
-                (io/input-stream path))]
-    (when @fail-on-error
-      (handle-errors states path))
-    states))
+  (read-input
+    (or force-format (path-format path))
+    (or initial-state st/default-state)
+    (io/input-stream path)))
 
 (defn read-paths
   "Given a format keyword (or nil to detect the format),

--- a/src/org/knotation/jena.clj
+++ b/src/org/knotation/jena.clj
@@ -110,8 +110,8 @@
   [input-format initial-state ^InputStream input]
   (->> input
        (read-basic-input input-format)
+       (map st/assign-subject)
        st/assign-stanzas
-       (st/update-states (or initial-state st/default-state))
        st/insert-events))
 
 (defn read-string

--- a/src/org/knotation/json_ld.cljc
+++ b/src/org/knotation/json_ld.cljc
@@ -59,6 +59,6 @@
 
 (defn render-stanza
   [env si states]
-  (util/edn->json
-   (render-stanza-edn env si states)
-   :escape-slash false))
+  (util/edn->json 
+    (render-stanza-edn env si states) 
+    :escape-slash false))

--- a/src/org/knotation/json_ld.cljc
+++ b/src/org/knotation/json_ld.cljc
@@ -60,5 +60,4 @@
 (defn render-stanza
   [env si states]
   (util/edn->json 
-    (render-stanza-edn env si states) 
-    :escape-slash false))
+    (render-stanza-edn env si states)))

--- a/src/org/knotation/state.cljc
+++ b/src/org/knotation/state.cljc
@@ -41,6 +41,9 @@
        (merge (when info {::error-info info}))
        (assoc state ::event ::error ::error)))
 
+
+;; TODO: can this be made more efficient?
+;; Fails for big inputs (e.g. NCBITaxon)
 (defn filter-errors
   "Given a lazy sequence of states, 
    return a filtered sequence with only error states.
@@ -366,8 +369,7 @@
              (-> states
                  last
                  (select-keys [::location ::rdf/stanza ::rdf/subject])
-                 (assoc ::event ::blank)))])))
-       butlast))
+                 (assoc ::event ::blank)))])))))
 
 (defn insert-stanza-events
   "Given a sequence of states, add ::stanza-start and ::stanza-end events as required."
@@ -418,5 +420,5 @@
   [states]
   (->> states
        insert-subject-events
-       insert-stanza-events
-       insert-stanza-separators))
+							insert-stanza-events
+							insert-stanza-separators))

--- a/src/org/knotation/state.cljc
+++ b/src/org/knotation/state.cljc
@@ -420,5 +420,5 @@
   [states]
   (->> states
        insert-subject-events
-							insert-stanza-events
-							insert-stanza-separators))
+       insert-stanza-events
+       insert-stanza-separators))

--- a/src/org/knotation/util.cljc
+++ b/src/org/knotation/util.cljc
@@ -32,9 +32,8 @@
        (cons run (partition-with f (seq (drop (count run) s))))))))
 
 (defn edn->json
-  [content & {:keys [escape-slash]
-  	           :or [escape-slash true]}]
-  #?(:clj (json/write-str content :escape-slash escape-slash)
+  [content]
+  #?(:clj (json/write-str content :escape-slash true)
      :cljs (.stringify js/JSON (clj->js content) nil 2)))
 
 (defn error

--- a/src/org/knotation/util.cljc
+++ b/src/org/knotation/util.cljc
@@ -33,7 +33,7 @@
 
 (defn edn->json
   [content]
-  #?(:clj (json/write-str content :escape-slash true)
+  #?(:clj (json/write-str content :escape-slash false)
      :cljs (.stringify js/JSON (clj->js content) nil 2)))
 
 (defn error

--- a/src/org/knotation/util.cljc
+++ b/src/org/knotation/util.cljc
@@ -32,8 +32,9 @@
        (cons run (partition-with f (seq (drop (count run) s))))))))
 
 (defn edn->json
-  [content]
-  #?(:clj (json/write-str content)
+  [content & {:keys [escape-slash]
+  	           :or [escape-slash true]}]
+  #?(:clj (json/write-str content :escape-slash escape-slash)
      :cljs (.stringify js/JSON (clj->js content) nil 2)))
 
 (defn error

--- a/test/org/knotation/jena_test.clj
+++ b/test/org/knotation/jena_test.clj
@@ -76,27 +76,17 @@ ex:s
   ex:p \"o\"^^ex:d ;
   ex:p _:o .")
 
-(def test-ttl-env
-  (-> {}
-      (en/add-prefix "ex" "http://example.com/")
-      (en/add-base "http://example.com/")))
-
 (def test-ttl-edn
   [{::st/event ::st/prefix ::en/prefix "ex" ::en/iri "http://example.com/"}
    {::st/event ::st/base
-    ::en/env (en/add-prefix {} "ex" "http://example.com/")
     ::en/base "http://example.com/"}
-   {::st/event ::st/blank
-    ::en/env test-ttl-env}
+   {::st/event ::st/blank}
    {::st/event ::st/stanza-start
-    ::en/env test-ttl-env
     ::rdf/stanza "http://example.com/s"}
    {::st/event ::st/subject-start
-    ::en/env test-ttl-env
     ::rdf/stanza "http://example.com/s"
     ::rdf/subject "http://example.com/s"}
    {::st/event ::st/statement
-    ::en/env test-ttl-env
     ::rdf/stanza "http://example.com/s"
     ::rdf/subject "http://example.com/s"
     ::rdf/quad
@@ -105,7 +95,6 @@ ex:s
            :pi "http://example.com/p"
            :oi "http://example.com/o"}}
    {::st/event ::st/statement
-    ::en/env test-ttl-env
     ::rdf/stanza "http://example.com/s"
     ::rdf/subject "http://example.com/s"
     ::rdf/quad
@@ -114,7 +103,6 @@ ex:s
            :pi "http://example.com/p"
            :oi "http://example.com/o"}}
    {::st/event ::st/statement
-    ::en/env test-ttl-env
     ::rdf/stanza "http://example.com/s"
     ::rdf/subject "http://example.com/s"
     ::rdf/quad
@@ -123,7 +111,6 @@ ex:s
            :pi "http://example.com/p"
            :oi "http://example.com/o"}}
    {::st/event ::st/statement
-    ::en/env test-ttl-env
     ::rdf/stanza "http://example.com/s"
     ::rdf/subject "http://example.com/s"
     ::rdf/quad
@@ -133,7 +120,6 @@ ex:s
            :ol "o"
            :di "http://www.w3.org/2001/XMLSchema#string"}}
    {::st/event ::st/statement
-    ::en/env test-ttl-env
     ::rdf/stanza "http://example.com/s"
     ::rdf/subject "http://example.com/s"
     ::rdf/quad
@@ -143,7 +129,6 @@ ex:s
            :ol "o"
            :lt "l"}}
    {::st/event ::st/statement
-    ::en/env test-ttl-env
     ::rdf/stanza "http://example.com/s"
     ::rdf/subject "http://example.com/s"
     ::rdf/quad
@@ -153,7 +138,6 @@ ex:s
            :ol "o"
            :di "http://example.com/d"}}
    {::st/event ::st/statement
-    ::en/env test-ttl-env
     ::rdf/stanza "http://example.com/s"
     ::rdf/subject "http://example.com/s"
     ::rdf/quad
@@ -162,17 +146,10 @@ ex:s
            :pi "http://example.com/p"
            :ob "_:b0"}}
    {::st/event ::st/subject-end
-    ::en/env test-ttl-env
     ::rdf/stanza "http://example.com/s"
     ::rdf/subject "http://example.com/s"}
    {::st/event ::st/stanza-end
-    ::en/env test-ttl-env
     ::rdf/stanza "http://example.com/s"}])
-
-(->> test-ttl-string
-     (jena/read-string :ttl st/default-state)
-     st/sequential-blank-nodes
-     (map println))
 
 (deftest test-ttl->edn
   (->> test-ttl-string
@@ -180,11 +157,6 @@ ex:s
        st/sequential-blank-nodes
        (= test-ttl-edn)
        is))
-
-(def test-rdfxml-env
-  (-> {}
-      (en/add-prefix "rdf" "http://www.w3.org/1999/02/22-rdf-syntax-ns#")
-      (en/add-prefix "ex" "http://example.com/")))
 
 (deftest test-rdfxml->edn
   (->> "<?xml version=\"1.0\"?>
@@ -202,20 +174,15 @@ ex:s
             ::en/prefix "rdf"
             ::en/iri "http://www.w3.org/1999/02/22-rdf-syntax-ns#"}
            {::st/event ::st/prefix
-            ::en/env (en/add-prefix {} "rdf" "http://www.w3.org/1999/02/22-rdf-syntax-ns#")
             ::en/prefix "ex"
             ::en/iri "http://example.com/"}
-           {::st/event ::st/blank
-            ::en/env test-rdfxml-env}
+           {::st/event ::st/blank}
            {::st/event ::st/stanza-start
-            ::en/env test-rdfxml-env
             ::rdf/stanza "http://example.com/s"}
            {::st/event ::st/subject-start
-            ::en/env test-rdfxml-env
             ::rdf/stanza "http://example.com/s"
             ::rdf/subject "http://example.com/s"}
            {::st/event ::st/statement
-            ::en/env test-rdfxml-env
             ::rdf/stanza "http://example.com/s"
             ::rdf/subject "http://example.com/s"
             ::rdf/quad
@@ -224,7 +191,6 @@ ex:s
                    :pi "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"
                    :oi "http://example.com/foo"}}
            {::st/event ::st/statement
-            ::en/env test-rdfxml-env
             ::rdf/stanza "http://example.com/s"
             ::rdf/subject "http://example.com/s"
             ::rdf/quad
@@ -233,7 +199,6 @@ ex:s
                    :pi "http://example.com/p"
                    :oi "http://example.com/o"}}
            {::st/event ::st/statement
-            ::en/env test-rdfxml-env
             ::rdf/stanza "http://example.com/s"
             ::rdf/subject "http://example.com/s"
             ::rdf/quad
@@ -243,7 +208,6 @@ ex:s
                    :ol "o"
                    :di "http://www.w3.org/2001/XMLSchema#string"}}
            {::st/event ::st/statement
-            ::en/env test-rdfxml-env
             ::rdf/stanza "http://example.com/s"
             ::rdf/subject "http://example.com/s"
             ::rdf/quad
@@ -253,7 +217,6 @@ ex:s
                    :ol "o"
                    :lt "l"}}
            {::st/event ::st/statement
-            ::en/env test-rdfxml-env
             ::rdf/stanza "http://example.com/s"
             ::rdf/subject "http://example.com/s"
             ::rdf/quad
@@ -263,10 +226,8 @@ ex:s
                    :ol "o"
                    :di "http://example.com/d"}}
            {::st/event ::st/subject-end
-            ::en/env test-rdfxml-env
             ::rdf/stanza "http://example.com/s"
             ::rdf/subject "http://example.com/s"}
            {::st/event ::st/stanza-end
-            ::en/env test-rdfxml-env
             ::rdf/stanza "http://example.com/s"}])
        is))


### PR DESCRIPTION
Makes error handling optional. The filtering for any error states is too inefficient for big inputs, such as NCBITaxonomy. By default, `knotation-cljc` will not fail on a parse error unless you include `-e`.